### PR TITLE
articlesのURL指定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   get "users/index"
-  resources :articles
+  scope :api do
+    scope :v1 do
+      resources :articles
+    end
+  end
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api, format: 'json' do
+  namespace :api, format: "json" do
     namespace :v1 do
       resources :articles
       mount_devise_token_auth_for "User", at: "auth"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
-  get "users/index"
-  scope :api do
-    scope :v1 do
+  namespace :api, format: 'json' do
+    namespace :v1 do
       resources :articles
+      mount_devise_token_auth_for "User", at: "auth"
     end
   end
-  mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe Article, type: :model do
   context "validation check" do
-    let!(:user){ create(:user) }
-    let(:article){ build( :article, user: user, title: title, body: body) }
-    let(:title){ Faker::Lorem.sentence }
-    let(:body){ Faker::Lorem.sentences }
-    subject{ article.valid? }
+    subject { article.valid? }
+
+    let!(:user) { create(:user) }
+    let(:article) { build(:article, user: user, title: title, body: body) }
+    let(:title) { Faker::Lorem.sentence }
+    let(:body) { Faker::Lorem.sentences }
+
     context "title,bodyが指定されている時" do
       it "記事がエラーすることなく作成される" do
         expect(subject).to eq true
@@ -14,14 +16,15 @@ RSpec.describe Article, type: :model do
     end
 
     context "titleが指定されていない時" do
-      let(:title){ nil }
+      let(:title) { nil }
       it "エラーする" do
         subject
         expect(article.errors.messages[:title]).to include "can't be blank"
       end
     end
+
     context "bodyが指定されていない時" do
-      let(:body){ nil }
+      let(:body) { nil }
       it "エラーする" do
         subject
         expect(article.errors.messages[:body]).to include "can't be blank"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -2,18 +2,21 @@ require "rails_helper"
 
 RSpec.describe Comment, type: :model do
   context "validation check" do
-    let!(:user){ create(:user) }
-    let!(:article){ create(:article, user: user) }
-    let(:comment){ build(:comment, user: user, article: article, content: content) }
-    let(:content){ Faker::Lorem.sentence }
-    subject{ comment.valid? }
+    subject { comment.valid? }
+
+    let!(:user) { create(:user) }
+    let!(:article) { create(:article, user: user) }
+    let(:comment) { build(:comment, user: user, article: article, content: content) }
+    let(:content) { Faker::Lorem.sentence }
+
     context "contentが指定されている時" do
       it "エラーすることなくcommentが作成される" do
         expect(subject).to eq true
       end
     end
+
     context "contentが指定されていない時" do
-      let(:content){ nil }
+      let(:content) { nil }
       it "エラーする" do
         subject
         expect(comment.errors.messages[:content]).to include "can't be blank"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,26 +2,30 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   context "validation check" do
-    let(:user){ build(:user, nickname: nickname, password: password, email: email) }
-    let(:nickname){ Faker::Internet.username }
-    let(:password){ Faker::Internet.password(min_length: 6) }
-    let(:email){ Faker::Internet.email }
-    subject{ user.valid? }
+    subject { user.valid? }
+
+    let(:user) { build(:user, nickname: nickname, password: password, email: email) }
+    let(:nickname) { Faker::Internet.username }
+    let(:password) { Faker::Internet.password(min_length: 6) }
+    let(:email) { Faker::Internet.email }
+
     context "nicknameを指定している時" do
       it "ユーザーがエラーすることなく作られる" do
         expect(subject).to eq true
       end
     end
+
     context "nicknameを指定していない時" do
-      let(:nickname){ nil }
+      let(:nickname) { nil }
       it "エラーする" do
         subject
         expect(user.errors.messages[:nickname]).to include "can't be blank"
       end
     end
+
     context "同じnicknameが存在している時" do
-      let!(:user_same){ create(:user, nickname: "harry") }
-      let(:nickname){ "harry" }
+      let!(:user_same) { create(:user, nickname: "harry") }
+      let(:nickname) { "harry" }
       it "エラーする" do
         subject
         expect(user.errors.messages[:nickname]).to include "has already been taken"
@@ -29,7 +33,7 @@ RSpec.describe User, type: :model do
     end
 
     context "emailを指定していない時" do
-      let(:email){ nil }
+      let(:email) { nil }
       it "エラーする" do
         subject
         expect(user.errors.messages[:email]).to include "can't be blank"
@@ -37,7 +41,7 @@ RSpec.describe User, type: :model do
     end
 
     context "passwordを指定していない時" do
-      let(:password){ nil }
+      let(:password) { nil }
       it "エラーする" do
         subject
         expect(user.errors.messages[:password]).to include "can't be blank"
@@ -45,7 +49,7 @@ RSpec.describe User, type: :model do
     end
 
     context "passwordが6文字未満の時" do
-      let(:password){ "aaa" }
+      let(:password) { "aaa" }
       it "エラーする" do
         subject
         expect(user.errors.messages[:password]).to include "is too short (minimum is 6 characters)"


### PR DESCRIPTION
## 概要
- articlesのルーティング実装
1. scopeを用いてURL（`/api/v1/articles`）の指定
2. resourcesを用いたルーティングの設定