### PR TITLE
記事一覧の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "coffee-rails", "~> 4.2"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem "jbuilder", "~> 2.5"
+
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby "2.7.2"
 
 gem "devise_token_auth"
 
+gem 'active_model_serializers', '~> 0.10.0'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 5.2.3"
 # Use mysql as the database for Active Record
@@ -25,7 +27,7 @@ gem "coffee-rails", "~> 4.2"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem "jbuilder", "~> 2.5"
+# gem "jbuilder", "~> 2.5"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,8 +96,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.2)
-      activesupport (>= 5.0.0)
     jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -275,7 +273,6 @@ DEPENDENCIES
   devise_token_auth
   factory_bot_rails
   faker
-  jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET /articles
   # GET /articles.json
   def index
-    @articles = Article.all
-    render json: @articles, each_serializer: ArticleSerializer
+    articles = Article.all
+    render json: articles, each_serializer: ArticleSerializer
   end
 
   # GET /articles/1

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,10 +1,11 @@
-class ArticlesController < ApplicationController
+class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: %i[show update destroy]
 
   # GET /articles
   # GET /articles.json
   def index
     @articles = Article.all
+    render json: @articles, each_serializer: ArticleSerializer
   end
 
   # GET /articles/1

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,3 +1,3 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body
+  attributes :id, :title, :body, :user_id
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.sentences }
+    user
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Articles", type: :request do
+  describe "GET api/v1/articles" do
+    subject{ get(api_v1_articles_path) }
+    before do
+      create_list(:article,3)
+    end
+    it "記事一覧が表示される" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id","title","body","user_id"]
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

> **active_model_serializerの導入**

- bundle exec rails g serializer articlesにより、article_serializer.rbを作成

> **articles_controllerの階層変更**

- controllers/api/v1に変更
- indexメソッドについては、active_model_serializerを使用してJSONを返す機能を実装

> **request specの実装**

- bundle exec rails g rspec:integration Articleによりspec/requestsにarticle_spec.rbを作成
- 記事一覧のrequest specを実装するため、factories/articles.rb内にassociation機能により`user`の記述を追加
- 記事一覧のrequest specを実装した
