### PR TITLE
記事詳細のAPIとrequest spec

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,16 +1,18 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
-  before_action :set_article, only: %i[show update destroy]
+  before_action :set_article, only: %i[update destroy]
 
-  # GET /articles
-  # GET /articles.json
+  # GET api/v1/articles
+  # GET api/v1/articles.json
   def index
     articles = Article.all
     render json: articles, each_serializer: ArticleSerializer
   end
 
-  # GET /articles/1
-  # GET /articles/1.json
+  # GET api/v1/articles/1
+  # GET api/v1/articles/1.json
   def show
+    article = Article.find(params[:id])
+    render json: article, each_serializer: ArticleSerializer
   end
 
   # POST /articles

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
-  before_action :set_article, only: %i[update destroy]
+  before_action :set_article, only: %i[show update destroy]
 
   # GET api/v1/articles
   # GET api/v1/articles.json
@@ -11,8 +11,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles/1
   # GET api/v1/articles/1.json
   def show
-    article = Article.find(params[:id])
-    render json: article, serializer: ArticleSerializer
+    render json: @article, serializer: ArticleSerializer
   end
 
   # POST /articles

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles/1.json
   def show
     article = Article.find(params[:id])
-    render json: article, each_serializer: ArticleSerializer
+    render json: article, serializer: ArticleSerializer
   end
 
   # POST /articles

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -14,4 +14,26 @@ RSpec.describe "Articles", type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe "GET api/v1/articles/:id" do
+    subject{ get(api_v1_article_path(article_id)) }
+    context "指定したidが存在する時" do
+      let!(:article){ create(:article) }
+      let(:article_id){ article.id }
+      it "指定された記事が表示される" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["user_id"]).to eq article.user_id
+        expect(response).to have_http_status(200)
+      end
+    end
+    context "指定したidが存在しない時" do
+      let(:article_id){ 0 }
+      it "エラーする" do
+        expect{ subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

> **記事詳細のAPI**

- ローカル変数を使用するため、set_articleからshowメソッドを削除
- active_model_serializerによりJSONを返すように設定

> **記事詳細のrequest spec**

- contextにより、指定したidが存在した場合と存在しない場合で場合分けをした