### PR TITLE
destroyの実装及びdestroyのrequest spec

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
-  before_action :set_article, only: %i[show destroy]
+  before_action :set_article, only: [:show]
 
   # GET api/v1/articles
   # GET api/v1/articles.json
@@ -29,10 +29,11 @@ class Api::V1::ArticlesController < Api::V1::ApiController
     render json: article
   end
 
-  # DELETE /articles/1
-  # DELETE /articles/1.json
+  # DELETE api/v1/articles/1
+  # DELETE api/v1/articles/1.json
   def destroy
-    @article.destroy
+    article = current_user.articles.find(params[:id])
+    article.destroy!
   end
 
   private

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -85,7 +85,30 @@ RSpec.describe "Articles", type: :request do
       let(:article){ create(:article) }
       it "エラーする" do
         expect{ subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 
+  describe "DELETE api/v1/articles/:id" do
+    subject { delete(api_v1_article_path(article_id)) }
+    before do
+      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
+    end
+    let!(:current_user){ create(:user) }
+    let!(:article){ create(:article, user: current_user) }
+    let!(:article_id){ article.id }
+
+    context "current_userが指定した記事を削除した時" do
+      it "記事は削除される" do
+        expect{ subject }.to change { current_user.articles.count }.by(-1)
+        expect(response).to have_http_status(204)
+      end
+    end
+    context "current_userが他の記事を削除しようとする時" do
+      let(:article){ create(:article) }
+      let(:article_id){ article.id }
+      it "エラーする" do
+        expect{ subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -82,33 +82,36 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "current_userが他の記事を編集した時" do
-      let(:article){ create(:article) }
+      let(:article) { create(:article) }
       it "エラーする" do
-        expect{ subject }.to raise_error ActiveRecord::RecordNotFound
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
 
   describe "DELETE api/v1/articles/:id" do
     subject { delete(api_v1_article_path(article_id)) }
+
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
     end
-    let!(:current_user){ create(:user) }
-    let!(:article){ create(:article, user: current_user) }
-    let!(:article_id){ article.id }
+
+    let!(:current_user) { create(:user) }
+    let!(:article) { create(:article, user: current_user) }
+    let!(:article_id) { article.id }
 
     context "current_userが指定した記事を削除した時" do
       it "記事は削除される" do
-        expect{ subject }.to change { current_user.articles.count }.by(-1)
-        expect(response).to have_http_status(204)
+        expect { subject }.to change { current_user.articles.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
       end
     end
+
     context "current_userが他の記事を削除しようとする時" do
-      let(:article){ create(:article) }
-      let(:article_id){ article.id }
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
       it "エラーする" do
-        expect{ subject }.to raise_error ActiveRecord::RecordNotFound
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end


### PR DESCRIPTION
## 概要

### destroyの実装
---

before_actionからdestroyを削除。

current_userの記事を削除するようにした。

### destroyのrequest spec 
---

**正常系のテスト**
current_userの指定されたarticlesを削除するようにした。

**異常系のテスト**
destroyメソッドはcurrent_userの`articles`を`find`した上で、削除しているので、current_user以外のuserが作成した`articles`は`find`できずエラーする。

テスト内容は以下のとおりである。

- 正常系のテスト

**1.current_userの指定された記事が削除されているか** 
**2.ステータスコードが204であること**

- 異常系のテスト

**1.current_userが他のuserのarticleを削除しようとした時にエラーすること**

---

- rubocop -aの実施