### PR TITLE
devise_token_authを用いた新規登録APIの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "devise_token_auth"
 
 gem "active_model_serializers", "~> 0.10.0"
 
+gem "rack-cors"
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 5.2.3"
 # Use mysql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -275,6 +277,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   rails-erd
   rspec-rails

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,4 @@
-class Api::V1::ApiController < ActionController::Base
-  include DeviseTokenAuth::Concerns::SetUserByToken
-  protect_from_forgery with: :null_session
+class Api::V1::ApiController < ApplicationController
 
   def current_user
     @current_user ||= User.first

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::ApiController < ApplicationController
-
   def current_user
     @current_user ||= User.first
   end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   private
-  def sign_up_params
-    params.permit(:nickname, :email, :password)
-  end
+
+    def sign_up_params
+      params.permit(:nickname, :email, :password)
+    end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Auth::RegistrationsController < Api::V1::ApiController
+  def create
+    user = User.new
+    render json: {
+      data: user
+    }
+  end
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,8 +1,6 @@
-class Api::V1::Auth::RegistrationsController < Api::V1::ApiController
-  def create
-    user = User.new
-    render json: {
-      data: user
-    }
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+  def sign_up_params
+    params.permit(:nickname, :email, :password)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,14 @@ module QiitaClone
 
     config.api_only = true
     config.middleware.use ActionDispatch::Flash
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*',
+          headers: :any,
+          expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
+          methods: [:get, :post, :options, :delete, :put]
+      end
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,11 +47,11 @@ module QiitaClone
     config.middleware.use ActionDispatch::Flash
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins '*'
-        resource '*',
-          headers: :any,
-          expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
-          methods: [:get, :post, :options, :delete, :put]
+        origins "*"
+        resource "*",
+                 headers: :any,
+                 expose: ["access-token", "expiry", "token-type", "uid", "client"],
+                 methods: [:get, :post, :options, :delete, :put]
       end
     end
   end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                          :'client' => 'client',
-                          :'expiry' => 'expiry',
-                          :'uid' => 'uid',
-                          :'token-type' => 'token-type' }
+  config.headers_names = { :'access-token' => "access-token",
+                           client => "client",
+                           expiry => "expiry",
+                           uid => "uid",
+                           :'token-type' => "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                          :'client' => 'client',
+                          :'expiry' => 'expiry',
+                          :'uid' => 'uid',
+                          :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :articles
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: 'api/v1/auth/registrations'
+        registrations: "api/v1/auth/registrations",
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
       resources :articles
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: 'api/v1/auth/registrations'
+      }
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "GET /index" do

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end


### PR DESCRIPTION
## 概要

### gemの追加
---

- rack-corsの追加について
- rack-corsについて調べたところ、別のオリジンからのサーバーへのアクセスを制御する機能だと理解した。
- 今回に関しては、どのオリジンからもアクセスできるようにした。

### コントローラーの追加
---

- `bundle exec rails routes | grep auth`について確認したところ、

```
cancel_api_v1_user_registration GET    /api/v1/auth/cancel(.:format)                                                            devise_token_auth/registrations#cancel {:format=>/json/}
   new_api_v1_user_registration GET    /api/v1/auth/sign_up(.:format)                                                           devise_token_auth/registrations#new {:format=>/json/}
  edit_api_v1_user_registration GET    /api/v1/auth/edit(.:format)                                                              devise_token_auth/registrations#edit {:format=>/json/}
       api_v1_user_registration PATCH  /api/v1/auth(.:format)                                                                   devise_token_auth/registrations#update {:format=>/json/}
                                PUT    /api/v1/auth(.:format)                                                                   devise_token_auth/registrations#update {:format=>/json/}
                                DELETE /api/v1/auth(.:format)                                                                   devise_token_auth/registrations#destroy {:format=>/json/}
                                POST   /api/v1/auth(.:format)                                                                   devise_token_auth/registrations#create {:format=>/json/}
     api_v1_auth_validate_token GET    /api/v1/auth/validate_token(.:format)                                                    devise_token_auth/token_validations#validate_token

```
であったことから、config/routes.rbを変更した。

```

cancel_api_v1_user_registration GET    /api/v1/auth/cancel(.:format)                                                            api/v1/auth/registrations#cancel {:format=>/json/}
   new_api_v1_user_registration GET    /api/v1/auth/sign_up(.:format)                                                           api/v1/auth/registrations#new {:format=>/json/}
  edit_api_v1_user_registration GET    /api/v1/auth/edit(.:format)                                                              api/v1/auth/registrations#edit {:format=>/json/}
       api_v1_user_registration PATCH  /api/v1/auth(.:format)                                                                   api/v1/auth/registrations#update {:format=>/json/}
                                PUT    /api/v1/auth(.:format)                                                                   api/v1/auth/registrations#update {:format=>/json/}
                                DELETE /api/v1/auth(.:format)                                                                   api/v1/auth/registrations#destroy {:format=>/json/}
                                POST   /api/v1/auth(.:format)                                                                   api/v1/auth/registrations#create {:format=>/json/}

```

`bundle exec rails g controller api/v1/auth/registrations`により、コントローラーを作成した。
specファイルは自動生成されたものである。

- コントローラー内の設定
createアクションを追加した。
とりあえずの処理として、responseで帰ってくるヘッダーにどんな情報があるか確認するために、newメソッドを定義した。


### device_token_auth.rbの編集
---

- `config.change_headers_on_each_request = true`だとリクエストのたびに認証ヘッダーが変わってしまうので、`false`にした。

- header-nameについてコメントインした。

### 詰まっているところ
---

- ヘッダー情報にacces-tokenの情報が載っていない。
`new`メソッドから`create!`メソッドに変更し、ストロングパラメーターにより値を指定した状態でendpointを叩き、ユーザーを登録してみたが、usersデータベースのtokensはNULLのままであり、ヘッダーに情報も出てこない。
そもそもtokensはデータベース上に表示されるのか。

- controller/api/v1/auth/registrationsの継承元が合っているか
現時点では、api/v1/api_controllerを継承元としているが、調べていると継承元がdevise_token_auth/registrations_contorllerのものが散見されたので、変更してみたが、internal server error(500)となる。

- 新規登録時にacces-tokenは自動生成されるものか
コード上で作成しなければいけないものなのかと考え、`token = DeviseTokenAuth::TokenFactory.create`を作成してみたが、どんなコードを書けば、ヘッダーにtokenの情報を載せられるかがわからない。


公式ドキュメントは読み込んでいるつもりなのですが、今回の課題に必要な情報を取り出すには、公式ドキュメントのどのあたりを読んだらいいか、どこを参考にしたらいいか教えていただければと思います。


