### PR TITLE
ログアウト機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,3 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.6
   Enabled: true
-  Exclude:
-    - 'config/initializers/devise_token_auth.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,5 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.6
   Enabled: true
+  Exclude:
+    - 'config/initializers/devise_token_auth.rb'

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
+  before_action :authenticate_api_v1_user!, only: [:destroy]
+
   private
 
     def resource_params

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,13 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = { :'access-token' => "access-token",
-                           :'client' => "client",
-                           :'expiry' => "expiry",
-                           :'uid' => "uid",
-                           :'token-type' => "token-type" }
+  config.headers_names = {
+    "access-token" => "access-token",
+    "client" => "client",
+    "expiry" => "expiry",
+    "uid" => "uid",
+    "token-type" => "token-type",
+  }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -43,9 +43,9 @@ DeviseTokenAuth.setup do |config|
 
   # Makes it possible to change the headers names
   config.headers_names = { :'access-token' => "access-token",
-                           client => "client",
-                           expiry => "expiry",
-                           uid => "uid",
+                           :'client' => "client",
+                           :'expiry' => "expiry",
+                           :'uid' => "uid",
                            :'token-type' => "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.


### PR DESCRIPTION
## 概要

- `sessions_controller.rb`に`before_action :authenticate_api_v1_user!`を追加
追加した意図としては、ログインユーザーからのリクエスト以外はエラーを返したかったからである。

- `.rubocop.yml`の編集
`rubocop -a`を実施すると`config/initializers/devise_token_auth.rb`の設定が崩れてしまうため、`.rubocop.yml`内に`rubocop -a`実施時における対象ファイルから除外するコードを追加した。
<img width="1440" alt="スクリーンショット 2021-07-05 6 37 27" src="https://user-images.githubusercontent.com/80399352/124401414-65d72a00-dd64-11eb-9d31-cc837ed57af6.png">
<img width="1440" alt="スクリーンショット 2021-07-05 7 35 58" src="https://user-images.githubusercontent.com/80399352/124401425-7b4c5400-dd64-11eb-88b2-ae51532607c7.png">
