### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_sign_in?, :api_v1_user_sign_in?
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: [:show]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   # GET api/v1/articles
   # GET api/v1/articles.json

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -43,11 +43,11 @@ DeviseTokenAuth.setup do |config|
 
   # Makes it possible to change the headers names
   config.headers_names = {
-    "access-token" => "access-token",
-    "client" => "client",
-    "expiry" => "expiry",
-    "uid" => "uid",
-    "token-type" => "token-type",
+    "access-token": "access-token",
+    client: "client",
+    expiry: "expiry",
+    uid: "uid",
+    "token-type": "token-type",
   }
 
   # By default, only Bearer Token authentication is implemented out of the box.

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
+    let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
     let(:params) { { article: attributes_for(:article) } }
 
@@ -60,13 +61,14 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PATCH api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
     end
 
     let!(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
     let(:article) { create(:article, user: current_user) }
     let(:article_id) { article.id }
     let(:params) { { article: { title: Faker::Lorem.sentence, created_at: Time.current } } }
@@ -90,13 +92,14 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
     end
 
     let!(:current_user) { create(:user) }
+    let!(:headers) { current_user.create_new_auth_token }
     let!(:article) { create(:article, user: current_user) }
     let!(:article_id) { article.id }
 


### PR DESCRIPTION
## 概要

- **api_v1_controllerにおけるdevise_token_authの各種メソッドの使用**
devise_token_authで定義されているhelperはgroup_nameがデフォルトで設定されていることから、メソッド名を別名に上書きするため、`alias_method`を定義し、`current_user`、`user_sign_in?`、`athenticate_user!`を使用できるようにした。

- **before_actionの設定**
articles_controllerに`before_action:authenticate_user!`を定義し、ログインしていなければ、使用できないAPIを指定した。

- **テストにheadersを渡すよう設定**
ログインユーザーの使用する機能に関するテストについては、headersを定義した。

- **エラー箇所の修正**
initialize/devise_token_authのconfig.header_nameのコードがエラーを引き起こしていたことから、修正した。

