### PR TITLE
下書き機能の実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,4 +3,5 @@ class Article < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
   validates :title, :body, presence: true
+  enum status: { draft: false, published: true }
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,5 +3,5 @@ class Article < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
   validates :title, :body, presence: true
-  enum status: { draft: false, published: true }
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20210712080959_add_status_to_article.rb
+++ b/db/migrate/20210712080959_add_status_to_article.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticle < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles, :status, :boolean, default: true, null: false
+    add_column :articles, :status, :string, default: "published", null: false
   end
 end

--- a/db/migrate/20210712080959_add_status_to_article.rb
+++ b/db/migrate/20210712080959_add_status_to_article.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_22_205918) do
+ActiveRecord::Schema.define(version: 2021_07_12_080959) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_05_22_205918) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.boolean "status", default: true, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_080959) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.boolean "status", default: true, null: false
+    t.string "status", default: "published", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.sentence }
+    status { :published }
     user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "validation check" do
+  describe "validation check" do
     subject { article.valid? }
 
     let!(:user) { create(:user) }
@@ -28,6 +28,22 @@ RSpec.describe Article, type: :model do
       it "エラーする" do
         subject
         expect(article.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+  end
+
+  describe "下書き機能の確認" do
+    let(:article){ create(:article, status: status) }
+    let(:status){ :published }
+    context "statusがpulishedの時" do
+      it "公開記事だけ取得できる" do
+        expect(article.status).to include "published"
+      end
+    end
+    context "statusがdraftの時" do
+      let(:status){ :draft }
+      it "下書き記事だけ取得できる" do
+        expect(article.status).to include "draft"
       end
     end
   end


### PR DESCRIPTION
## 概要

- **articlesに`status`カラムを追加**
articlesのdbに`status`カラムを追加するmigrationファイルを作成し、`rails db:migrate`した。

- **articleモデルに`enum`の設定**
`status`の状態が`published(true)`の場合は、公開記事、`draft(false)`の時は、下書き記事とした。
なお、defaultは`published`に設定した。

- **article-specとfactriesの調整**
カラムの追加に伴い、factoriesにstatusを追加し、デフォルト値である`published`を設定した。
article_specに下書き機能を確認するテストを追加した。
確認事項は、下記2点である。
  - `status`が`published`の時、公開記事だけ取得できる
  - `status`が`draft`の時、下書き記事だけ取得できる

