### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles.json
   def index
     articles = Article.all
-    article_p = articles.select{|article| article.status == "published" }
+    article_p = articles.select {|article| article.status == "published" }
     render json: article_p, each_serializer: ArticleSerializer
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles
   # GET api/v1/articles.json
   def index
-    articles = Article.where(status: :published)
+    articles = Article.published
     render json: articles, each_serializer: ArticleSerializer
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -6,7 +6,8 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles.json
   def index
     articles = Article.all
-    render json: articles, each_serializer: ArticleSerializer
+    article_p = articles.select{|article| article.status == "published" }
+    render json: article_p, each_serializer: ArticleSerializer
   end
 
   # GET api/v1/articles/1
@@ -46,6 +47,6 @@ class Api::V1::ArticlesController < Api::V1::ApiController
 
     # Only allow a list of trusted parameters through.
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,9 +5,8 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   # GET api/v1/articles
   # GET api/v1/articles.json
   def index
-    articles = Article.all
-    article_p = articles.select {|article| article.status == "published" }
-    render json: article_p, each_serializer: ArticleSerializer
+    articles = Article.where(status: :published)
+    render json: articles, each_serializer: ArticleSerializer
   end
 
   # GET api/v1/articles/1

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,6 +2,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
-  validates :title, :body, presence: true
+  validates :title, :body, :status, presence: true
   enum status: { draft: "draft", published: "published" }
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,4 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -42,15 +42,16 @@ RSpec.describe Article, type: :model do
   end
 
   describe "下書き機能の確認" do
-    let(:article){ create(:article, status: status) }
-    let(:status){ :published }
+    let(:article) { create(:article, status: status) }
+    let(:status) { :published }
     context "statusがpulishedの時" do
       it "公開記事だけ取得できる" do
         expect(article.status).to include "published"
       end
     end
+
     context "statusがdraftの時" do
-      let(:status){ :draft }
+      let(:status) { :draft }
       it "下書き記事だけ取得できる" do
         expect(article.status).to include "draft"
       end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe Article, type: :model do
     subject { article.valid? }
 
     let!(:user) { create(:user) }
-    let(:article) { build(:article, user: user, title: title, body: body) }
+    let(:article) { build(:article, user: user, title: title, body: body, status: status) }
     let(:title) { Faker::Lorem.sentence }
     let(:body) { Faker::Lorem.sentences }
+    let(:status) { :published }
 
-    context "title,bodyが指定されている時" do
+    context "title,body,statusが指定されている時" do
       it "記事がエラーすることなく作成される" do
         expect(subject).to eq true
       end
@@ -28,6 +29,14 @@ RSpec.describe Article, type: :model do
       it "エラーする" do
         subject
         expect(article.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+
+    context "statusが指定されていない時" do
+      let(:status) { nil }
+      it "エラーする" do
+        subject
+        expect(article.errors.messages[:status]).to include "can't be blank"
       end
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe "Articles", type: :request do
     before do
       create_list(:article, 3)
     end
+
     context "statusがpublishedの時" do
       it "公開記事一覧が表示される" do
         subject
         res = JSON.parse(response.body)
         expect(res.length).to eq 3
-        expect(res[0].keys).to eq ["id", "title", "body", "status","updated_at", "user"]
+        expect(res[0].keys).to eq ["id", "title", "body", "status", "updated_at", "user"]
         expect(res[0].value?("published")).to eq true
         expect(response).to have_http_status(:ok)
       end
@@ -47,8 +48,8 @@ RSpec.describe "Articles", type: :request do
 
     let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
-    let(:params) { { article: {title: Faker::Lorem.sentence, body: Faker::Lorem.sentence, status: status} } }
-    let(:status){ :published }
+    let(:params) { { article: { title: Faker::Lorem.sentence, body: Faker::Lorem.sentence, status: status } } }
+    let(:status) { :published }
 
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
@@ -64,7 +65,7 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "current_userがstatusをdraftを指定した時" do
-      let(:status){ :draft }
+      let(:status) { :draft }
       it "下書き記事が作成される" do
         expect { subject }.to change { current_user.articles.count }.by(1)
         res = JSON.parse(response.body)
@@ -83,7 +84,7 @@ RSpec.describe "Articles", type: :request do
 
     let!(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
-    let(:status){ :published }
+    let(:status) { :published }
     let(:article) { create(:article, user: current_user, status: status) }
     let(:article_id) { article.id }
     let(:params) { { article: { title: Faker::Lorem.sentence, created_at: Time.current } } }
@@ -93,26 +94,26 @@ RSpec.describe "Articles", type: :request do
         expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
                               not_change { Article.find(article_id).body } &
                               not_change { Article.find(article_id).user } &
-                              not_change { Article.find(article_id).status} &
+                              not_change { Article.find(article_id).status } &
                               not_change { Article.find(article_id).created_at }
         expect(response).to have_http_status(:ok)
       end
     end
 
     context "current_userが指定した下書き記事を編集した時" do
-      let(:status){ :draft }
+      let(:status) { :draft }
       it "下書き記事は編集される" do
         expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
                               not_change { Article.find(article_id).body } &
                               not_change { Article.find(article_id).user } &
-                              not_change { Article.find(article_id).status} &
+                              not_change { Article.find(article_id).status } &
                               not_change { Article.find(article_id).created_at }
         expect(response).to have_http_status(:ok)
       end
     end
 
     context "current_userが公開記事を下書き記事に編集した時" do
-      let(:params){ {article: { status: "draft" } } }
+      let(:params) { { article: { status: "draft" } } }
       it "下書き記事に編集される" do
         expect { subject }.to change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
                               not_change { Article.find(article_id).title } &
@@ -123,8 +124,8 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "current_userが下書き記事を公開記事に編集した時" do
-      let(:status){ :draft }
-      let(:params){ {article: { status: "published" } } }
+      let(:status) { :draft }
+      let(:params) { { article: { status: "published" } } }
       it "公開記事に編集される" do
         expect { subject }.to change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
                               not_change { Article.find(article_id).title } &

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe "Articles", type: :request do
     before do
       create_list(:article, 3)
     end
-
-    it "記事一覧が表示される" do
-      subject
-      res = JSON.parse(response.body)
-      expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
-      expect(response).to have_http_status(:ok)
+    context "statusがpublishedの時" do
+      it "公開記事一覧が表示される" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "body", "status","updated_at", "user"]
+        expect(res[0].value?("published")).to eq true
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 
@@ -45,16 +47,29 @@ RSpec.describe "Articles", type: :request do
 
     let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: {title: Faker::Lorem.sentence, body: Faker::Lorem.sentence, status: status} } }
+    let(:status){ :published }
 
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
     end
 
-    context "current_userが記事を作成した時" do
-      it "記事は作成される" do
+    context "current_userがstatusをpublishedに指定した時" do
+      it "公開記事が作成される" do
         expect { subject }.to change { current_user.articles.count }.by(1)
+        res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
+        expect(res["status"]).to include "published"
+      end
+    end
+
+    context "current_userがstatusをdraftを指定した時" do
+      let(:status){ :draft }
+      it "下書き記事が作成される" do
+        expect { subject }.to change { current_user.articles.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["status"]).to include "draft"
       end
     end
   end
@@ -68,15 +83,52 @@ RSpec.describe "Articles", type: :request do
 
     let!(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
-    let(:article) { create(:article, user: current_user) }
+    let(:status){ :published }
+    let(:article) { create(:article, user: current_user, status: status) }
     let(:article_id) { article.id }
     let(:params) { { article: { title: Faker::Lorem.sentence, created_at: Time.current } } }
 
-    context "current_userが指定した記事を編集した時" do
-      it "記事は編集される" do
+    context "current_userが指定した公開記事を編集した時" do
+      it "公開記事は編集される" do
         expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
                               not_change { Article.find(article_id).body } &
-                              not_change { Article.find(article_id).user_id } &
+                              not_change { Article.find(article_id).user } &
+                              not_change { Article.find(article_id).status} &
+                              not_change { Article.find(article_id).created_at }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "current_userが指定した下書き記事を編集した時" do
+      let(:status){ :draft }
+      it "下書き記事は編集される" do
+        expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
+                              not_change { Article.find(article_id).body } &
+                              not_change { Article.find(article_id).user } &
+                              not_change { Article.find(article_id).status} &
+                              not_change { Article.find(article_id).created_at }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "current_userが公開記事を下書き記事に編集した時" do
+      let(:params){ {article: { status: "draft" } } }
+      it "下書き記事に編集される" do
+        expect { subject }.to change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
+                              not_change { Article.find(article_id).title } &
+                              not_change { Article.find(article_id).user } &
+                              not_change { Article.find(article_id).created_at }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "current_userが下書き記事を公開記事に編集した時" do
+      let(:status){ :draft }
+      let(:params){ {article: { status: "published" } } }
+      it "公開記事に編集される" do
+        expect { subject }.to change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
+                              not_change { Article.find(article_id).title } &
+                              not_change { Article.find(article_id).user } &
                               not_change { Article.find(article_id).created_at }
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
## 概要

- **article_modelのvalidation変更**
ユーザーが作成した記事について、下書き記事か公開記事かを選択させるため、`:status, presence: true`に設定した。
なお、validationの変更に伴い、`article_spec`の`validation_check`の項目について、`status: nil`だった場合のspecを追加した。

- **articles_controllerの変更**
記事一覧は公開記事のみ反映されるように変更し、create,updateに設定されている`article_params`に`:status`を追加した。

- **article_controllerの変更に伴うrequests_specの編集**
articles_controllerの変更に伴い、articles_specのテストを一部修正、追加した。
変更に伴うテスト事項は下記のとおりである。
  - 記事一覧取得の際、公開記事のみが取得できているか。
  - 記事作成の際、statusのいずれかの選択により、公開記事もしくは下書き記事が作成されているか
  - 記事編集については、公開記事を編集した場合、下書き記事を編集した場合、公開記事を下書き記事に編集した場合、下書き記事を公開記事に編集した場合にその他に変更がないか


