### PR TITLE
自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -5,5 +5,4 @@ class Api::V1::Current::ArticlesController < Api::V1::ApiController
     articles = current_user.articles.published
     render json: articles
   end
-
 end

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::Current::ArticlesController < Api::V1::ApiController
+  before_action :authenticate_user!
+
+  def index
+    articles = current_user.articles.published
+    render json: articles
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Mypage", type: :request do
         subject
         res = JSON.parse(response.body)
         expect(res.length).to eq current_user.articles.published.length
+        expect(res[0].value?("published")).to eq true
         expect(res).to not_include current_user.articles.draft
         expect(res).to not_include user.articles
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Mypage", type: :request do
     before do
       create_list(:article, 3, user: current_user)
       create_list(:article, 2, user: current_user, status: :draft)
-      create_list(:article, 3, user: user)
+      create_list(:article, 2, user: user)
     end
 
     context "current_userがmypageに接続した時" do
@@ -18,9 +18,7 @@ RSpec.describe "Mypage", type: :request do
         subject
         res = JSON.parse(response.body)
         expect(res.length).to eq current_user.articles.published.length
-        expect(res[0].values).to include "published"
-        expect(res).to not_include current_user.articles.draft
-        expect(res).to not_include user.articles
+        expect(res[0].keys).to eq ["id", "title", "body", "status","updated_at", "user"]
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Mypage", type: :request do
   describe "GET api/v1/current/articles" do
-    subject{ get(api_v1_current_articles_path, headers: headers) }
+    subject { get(api_v1_current_articles_path, headers: headers) }
 
-    let!(:current_user){ create(:user) }
-    let!(:user){ create(:user) }
-    let(:headers){ current_user.create_new_auth_token }
+    let!(:current_user) { create(:user) }
+    let!(:user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
     before do
       create_list(:article, 3, user: current_user)
       create_list(:article, 2, user: current_user, status: :draft)

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Mypage", type: :request do
         subject
         res = JSON.parse(response.body)
         expect(res.length).to eq current_user.articles.published.length
-        expect(res[0].value?("published")).to eq true
+        expect(res[0].values).to include "published"
         expect(res).to not_include current_user.articles.draft
         expect(res).to not_include user.articles
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Mypage", type: :request do
+  describe "GET api/v1/current/articles" do
+    subject{ get(api_v1_current_articles_path, headers: headers) }
+
+    let!(:current_user){ create(:user) }
+    let!(:user){ create(:user) }
+    let(:headers){ current_user.create_new_auth_token }
+    before do
+      create_list(:article, 3, user: current_user)
+      create_list(:article, 2, user: current_user, status: :draft)
+      create_list(:article, 3, user: user)
+    end
+
+    context "current_userがmypageに接続した時" do
+      it "current_userの公開記事一覧が表示される" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq current_user.articles.published.length
+        expect(res).to not_include current_user.articles.draft
+        expect(res).to not_include user.articles
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- **endpointの追加**
`routes.rb`に`namespace current do`でarticlesを追加し、endpoint `api/v1/current/articles`を作成した。

- **current/articles_controllerの追加**
endpoint `api/v1/current/articles`に対応した`current/articles_controller`を作成し、コントローラー内にindexメソッドを定義し、ユーザーの公開記事一覧が取得できるようにした。

- **current/articles_specの追加**
`current/articles_controller`等の追加により、`current/articles_spec`を追加した。
テスト事項は下記の通りである。
  - 表示されているのはcurrent_userの公開記事のみか。
  - 表示されている記事にdraft(下書き)は含まれていないか。
  - 他のユーザーの記事は含まれていないか。